### PR TITLE
Reasoning arg and response reasoning parsing

### DIFF
--- a/utils/ai/src/agent.rs
+++ b/utils/ai/src/agent.rs
@@ -352,7 +352,6 @@ impl Agent {
 
         let mut tool_calls = vec![];
         while let Some(evt) = stream.try_next().await? {
-            tracing::info!("evt: {:?}", evt);
             match serde_json::from_str::<ResponseStreamEvent>(&evt.data).unwrap() {
                 ResponseStreamEvent::OutputTextDelta(_) => {
                     let _ = tx.send(Ok(evt));

--- a/utils/ai/src/agent.rs
+++ b/utils/ai/src/agent.rs
@@ -443,6 +443,9 @@ impl Agent {
                 OutputItem::FileSearchCall(_) => {
                     // Currently ignored for non-streaming mode; nothing to add to context
                 }
+                OutputItem::Reasoning(_) => {
+                    // Do nothing for now
+                }
             }
         }
 

--- a/utils/ai/src/agent.rs
+++ b/utils/ai/src/agent.rs
@@ -326,7 +326,10 @@ impl Agent {
             .stream(true)
             .tools(self.tools.iter().cloned().map(Into::into).collect())
             .tool_choice(ToolChoice::Option(ToolChoiceOption::Auto))
-            .reasoning(ReasoningConfig::Effort(ReasoningEffortConfig::Minimal))
+            .reasoning(ReasoningConfig {
+                effort: Some(ReasoningEffortConfig::Minimal),
+                summary: None,
+            })
             .build()
             .expect("builder builds. qed");
 
@@ -349,6 +352,7 @@ impl Agent {
 
         let mut tool_calls = vec![];
         while let Some(evt) = stream.try_next().await? {
+            tracing::info!("evt: {:?}", evt);
             match serde_json::from_str::<ResponseStreamEvent>(&evt.data).unwrap() {
                 ResponseStreamEvent::OutputTextDelta(_) => {
                     let _ = tx.send(Ok(evt));

--- a/utils/ai/src/agent.rs
+++ b/utils/ai/src/agent.rs
@@ -4,6 +4,7 @@ use crate::openai::{
         FunctionTool, FunctionToolCall, Includable, InputFunctionCallOutput, InputItem,
         InputMessage, MessageRole, OutputItem, RequestPayloadBuilder, ToolChoice, ToolChoiceOption,
         streaming::ResponseStreamEvent,
+        ReasoningConfig, ReasoningEffortConfig,
     },
 };
 
@@ -325,6 +326,7 @@ impl Agent {
             .stream(true)
             .tools(self.tools.iter().cloned().map(Into::into).collect())
             .tool_choice(ToolChoice::Option(ToolChoiceOption::Auto))
+            .reasoning(ReasoningConfig::Effort(ReasoningEffortConfig::Minimal))
             .build()
             .expect("builder builds. qed");
 

--- a/utils/ai/src/openai.rs
+++ b/utils/ai/src/openai.rs
@@ -148,7 +148,7 @@ pub mod responses {
 
         /// Configuration options for reasoning models.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub reasoning: Option<Reasoning>,
+        pub reasoning: Option<ReasoningConfig>,
 
         /// Specifies the latency tier to use.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -220,6 +220,30 @@ pub mod responses {
                 user: None,
             }
         }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ReasoningConfig {
+        Effort(ReasoningEffortConfig),
+        Summary(ReasoningSummaryConfig),
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ReasoningEffortConfig {
+        Minimal,
+        Low, 
+        Medium,
+        High,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ReasoningSummaryConfig {
+        Auto, 
+        Concise,
+        Detailed,
     }
 
     #[derive(Deserialize, Clone, Debug)]
@@ -934,7 +958,6 @@ pub mod responses {
     }
 
     // --- Tool Definitions ---
-
     /// Ranking options for search.
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
     pub struct FileSearchRankingOptions {

--- a/utils/ai/src/openai.rs
+++ b/utils/ai/src/openai.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 pub const TEXT_EMBEDDING_3_SMALL: &str = "text-embedding-3-small";
 pub const GPT4_O: &str = "gpt-4o";
 pub const GPT4_O_MINI: &str = "gpt-4o-mini";
+//#NOTE GPT 5 stuff, reasoning models
+pub const GPT5: &str = "gpt-5";
+pub const GPT5_MINI: &str = "gpt-5-mini";
 pub const API_URL_V1: &str = "https://api.openai.com/v1";
 
 #[derive(Serialize)]

--- a/utils/ai/src/openai.rs
+++ b/utils/ai/src/openai.rs
@@ -478,6 +478,7 @@ pub mod responses {
         FunctionCall(FunctionToolCall),
         Message(OutputMessage),
         FileSearchCall(FileSearchToolCall),
+        Reasoning(ReasoningItem)
     }
 
     // --- Input Types ---

--- a/utils/ai/src/openai.rs
+++ b/utils/ai/src/openai.rs
@@ -223,10 +223,11 @@ pub mod responses {
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(rename_all = "snake_case")]
-    pub enum ReasoningConfig {
-        Effort(ReasoningEffortConfig),
-        Summary(ReasoningSummaryConfig),
+    pub struct ReasoningConfig {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub effort: Option<ReasoningEffortConfig>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub summary: Option<ReasoningSummaryConfig>,
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -273,7 +274,7 @@ pub mod responses {
         #[serde(default)]
         pub previous_response_id: Option<String>,
         #[serde(default)]
-        pub reasoning: Option<Reasoning>, // Use Reasoning from parent
+        pub reasoning: Option<ReasoningConfig>, // Use Reasoning from parent
         #[serde(default)]
         pub service_tier: Option<String>, // Present in initial event, might differ in final? Keep optional.
         #[serde(default)]
@@ -1130,7 +1131,7 @@ pub mod responses {
 
     /// Placeholder for Shared.Reasoning if definition is unknown
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
-    pub struct Reasoning {}
+    pub struct _Reasoning {}
 
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
     pub struct Usage {


### PR DESCRIPTION
- Added structs for the reasoning param in requests.
- Added ReasoningItem to OutputItem enum

Since reasoning is always included in the request, this version won't work with non-reasoning models.